### PR TITLE
Refine workflow adapter and converter tests

### DIFF
--- a/unified_workflow/tests/test_adapters_exports.py
+++ b/unified_workflow/tests/test_adapters_exports.py
@@ -1,0 +1,82 @@
+"""Unit tests validating adapter module re-exports."""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+
+def _get_all_attribute_names(module: object) -> List[str]:
+    """Return the module's public attribute list based on ``__all__``."""
+
+    all_attr = getattr(module, "__all__", None)
+    if all_attr is None:
+        pytest.fail("Adapter module is missing an __all__ attribute")
+    return list(all_attr)
+
+
+def test_project_generator_adapter_exports() -> None:
+    """Ensure project generator adapter exposes canonical classes."""
+
+    from project_generator.core.brief_parser import BriefParser
+    from project_generator.core.generator import ProjectGenerator
+    from project_generator.core.industry_config import IndustryConfig
+    from project_generator.core.validator import ProjectValidator
+    from project_generator.templates.registry import TemplateRegistry
+    from unified_workflow.automation.adapters import project_generator_adapter as adapter
+
+    exported = _get_all_attribute_names(adapter)
+    expected_names = [
+        "ProjectGenerator",
+        "ProjectValidator",
+        "IndustryConfig",
+        "BriefParser",
+        "TemplateRegistry",
+    ]
+
+    assert len(exported) == len(expected_names)
+    assert set(exported) == set(expected_names)
+    assert adapter.ProjectGenerator is ProjectGenerator
+    assert adapter.ProjectValidator is ProjectValidator
+    assert adapter.IndustryConfig is IndustryConfig
+    assert adapter.BriefParser is BriefParser
+    assert adapter.TemplateRegistry is TemplateRegistry
+
+
+def test_workflow_automation_adapter_exports() -> None:
+    """Validate workflow automation adapter re-exports core orchestrator types."""
+
+    from scripts.workflow_automation import WorkflowConfig, WorkflowOrchestrator
+    from scripts.workflow_automation.exceptions import GateFailedError, WorkflowError
+    from unified_workflow.automation.adapters import workflow_automation_adapter as adapter
+
+    exported = _get_all_attribute_names(adapter)
+    expected_names = [
+        "WorkflowConfig",
+        "WorkflowOrchestrator",
+        "GateFailedError",
+        "WorkflowError",
+    ]
+
+    assert len(exported) == len(expected_names)
+    assert set(exported) == set(expected_names)
+    assert adapter.WorkflowConfig is WorkflowConfig
+    assert adapter.WorkflowOrchestrator is WorkflowOrchestrator
+    assert adapter.GateFailedError is GateFailedError
+    assert adapter.WorkflowError is WorkflowError
+
+
+def test_lifecycle_tasks_adapter_exports() -> None:
+    """Confirm lifecycle tasks adapter provides module and helper access."""
+
+    from scripts import lifecycle_tasks
+    from unified_workflow.automation.adapters import lifecycle_tasks_adapter as adapter
+
+    exported = _get_all_attribute_names(adapter)
+    expected_names = ["lifecycle_tasks", "build_plan"]
+
+    assert len(exported) == len(expected_names)
+    assert set(exported) == set(expected_names)
+    assert adapter.lifecycle_tasks is lifecycle_tasks
+    assert adapter.build_plan is lifecycle_tasks.build_plan

--- a/unified_workflow/tests/test_evidence_schema_converter_unit.py
+++ b/unified_workflow/tests/test_evidence_schema_converter_unit.py
@@ -1,0 +1,116 @@
+"""Unit tests for evidence schema conversion helpers."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, List
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def _ensure_project_generator_package() -> None:
+    """Ensure the ``project_generator`` package resolves relative to the repository root."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    for module_name in list(sys.modules):
+        if module_name == "project_generator" or module_name.startswith("project_generator."):
+            sys.modules.pop(module_name)
+
+    importlib.invalidate_caches()
+    importlib.import_module("project_generator")
+
+
+_ensure_project_generator_package()
+
+from unified_workflow.core.evidence_schema_converter import (
+    EvidenceSchemaConverter,
+    convert_legacy_evidence,
+)
+
+
+def _build_standard_legacy_records() -> List[Dict[str, Any]]:
+    """Create representative legacy evidence entries."""
+
+    return [
+        {
+            "path": "docs/README.md",
+            "category": "documentation",
+            "description": "Project overview",
+            "checksum": "abc123",
+            "created_at": "2025-01-01T00:00:00Z",
+        },
+        {
+            "path": "src/app.py",
+            "category": "code",
+            "description": "Application module",
+            "checksum": "def456",
+            "created_at": "2025-01-01T01:00:00Z",
+        },
+    ]
+
+
+def _sanitise_dynamic_metadata(evidence: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of ``evidence`` with unstable timestamps removed."""
+
+    cleaned = deepcopy(evidence)
+    cleaned["manifest"]["metadata"].pop("generated_at", None)
+    cleaned["run_log"]["metadata"].pop("last_updated", None)
+    cleaned["validation"]["metadata"].pop("last_updated", None)
+    if cleaned["run_log"]["entries"]:
+        cleaned["run_log"]["entries"][0].pop("timestamp", None)
+    if cleaned["validation"]["phases"]:
+        cleaned["validation"]["phases"][0].pop("validated_at", None)
+    return cleaned
+
+
+def test_convert_legacy_evidence_matches_converter() -> None:
+    """Compatibility helper should delegate to the converter implementation."""
+
+    legacy = _build_standard_legacy_records()
+    helper_output = convert_legacy_evidence(legacy, "demo-project", phase=2)
+    direct_output = EvidenceSchemaConverter.legacy_to_unified(legacy, "demo-project", phase=2)
+
+    assert _sanitise_dynamic_metadata(helper_output) == _sanitise_dynamic_metadata(direct_output)
+    assert helper_output["manifest"]["metadata"]["project_name"] == "demo-project"
+    assert helper_output["validation"]["phases"][0]["phase"] == 2
+
+
+def test_legacy_to_unified_supports_workflow1_records() -> None:
+    """Records using the workflow1 structure should be normalized correctly."""
+
+    legacy = [
+        {
+            "file": "artifacts/report.md",
+            "phase": 3,
+            "project": "demo",
+            "checksum": "xyz789",
+            "timestamp": "2025-02-01T00:00:00Z",
+        }
+    ]
+
+    unified = EvidenceSchemaConverter.legacy_to_unified(legacy, "demo", phase=3)
+
+    artifact = unified["manifest"]["artifacts"][0]
+    assert artifact["path"] == "artifacts/report.md"
+    assert artifact["phase"] == 3
+    assert artifact["description"].startswith("Phase 3 artifact")
+
+
+def test_unified_to_legacy_strips_phase_information() -> None:
+    """Round-trip conversion should drop phase metadata to match legacy format."""
+
+    legacy = _build_standard_legacy_records()
+    unified = EvidenceSchemaConverter.legacy_to_unified(legacy, "demo", phase=1)
+    round_tripped = EvidenceSchemaConverter.unified_to_legacy(unified)
+
+    for original, converted in zip(legacy, round_tripped, strict=True):
+        assert "phase" not in converted
+        assert converted["path"] == original["path"]
+        assert converted["category"] == original["category"]
+        assert converted["description"] == original["description"]
+        assert converted["checksum"] == original["checksum"]

--- a/unified_workflow/tests/test_template_registry_unit.py
+++ b/unified_workflow/tests/test_template_registry_unit.py
@@ -1,0 +1,109 @@
+"""Focused unit tests for the unified template registry."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+from unified_workflow.core.template_registry import TemplateMetadata, UnifiedTemplateRegistry
+
+
+def _write_file(path: Path, content: str) -> None:
+    """Create a file with UTF-8 encoded content."""
+
+    path.write_text(content, encoding="utf-8")
+
+
+def _create_template(
+    base_path: Path,
+    template_type: str,
+    directory_name: str,
+    *,
+    manifest_name: str | None = None,
+    variants: Iterable[str] | None = None,
+) -> Path:
+    """Create a fake template directory structure for testing."""
+
+    variant_list: List[str] = list(variants or ("base",))
+    template_dir = base_path / template_type / directory_name
+    template_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_path = template_dir / "template.manifest.json"
+    manifest_payload = {
+        "name": manifest_name or directory_name,
+        "type": template_type,
+        "variants": variant_list,
+        "description": f"Mock template {directory_name}",
+    }
+    _write_file(manifest_path, json.dumps(manifest_payload))
+
+    for variant in variant_list:
+        variant_dir = template_dir / variant
+        variant_dir.mkdir(parents=True, exist_ok=True)
+        _write_file(variant_dir / "README.md", f"# {directory_name} ({variant})\n")
+        if template_type == "frontend":
+            _write_file(variant_dir / "package.json", "{}")
+        else:
+            _write_file(variant_dir / "requirements.txt", "flask\n")
+
+    return template_dir
+
+
+def test_registry_discovers_primary_templates(tmp_path: Path) -> None:
+    """Registry should enumerate templates located in the primary search path."""
+
+    primary_base = tmp_path / "template-packs"
+    _create_template(primary_base, "frontend", "react_app", variants=("base", "minimal"))
+
+    registry = UnifiedTemplateRegistry(root_path=tmp_path)
+    registry.initialize()
+
+    templates = registry.list_templates()
+    assert len(templates) == 1
+
+    metadata: TemplateMetadata = templates[0]
+    assert metadata.name == "react_app"
+    assert metadata.type.value == "frontend"
+    assert metadata.variants == ["base", "minimal"]
+    assert registry.get_template_path("frontend", "react_app", "minimal") == metadata.path / "minimal"
+
+
+def test_registry_prefers_higher_priority_paths(tmp_path: Path) -> None:
+    """Higher-priority search paths should override legacy duplicates."""
+
+    legacy_base = tmp_path / "project_generator" / "template-packs"
+    primary_base = tmp_path / "template-packs"
+
+    legacy_template = _create_template(legacy_base, "backend", "service_legacy", manifest_name="service")
+    primary_template = _create_template(primary_base, "backend", "service_primary", manifest_name="service")
+
+    registry = UnifiedTemplateRegistry(root_path=tmp_path)
+    registry.initialize()
+
+    metadata = registry.get_template("backend", "service")
+    assert metadata is not None
+    assert metadata.path == primary_template
+
+    manifest = registry.export_manifest()
+    manifest_entry = manifest["templates"]["backend/service"]
+    assert Path(manifest_entry["path"]) == primary_template
+
+
+def test_add_template_location_discovers_templates(tmp_path: Path) -> None:
+    """Adding a custom template location should trigger discovery on reinitialization."""
+
+    registry = UnifiedTemplateRegistry(root_path=tmp_path)
+    registry.initialize()
+
+    custom_base = tmp_path / "custom_templates"
+    _create_template(custom_base, "database", "analytics")
+
+    registry.add_template_location(custom_base, priority=0)
+
+    metadata = registry.get_template("database", "analytics")
+    assert metadata is not None
+    assert metadata.path == custom_base / "database" / "analytics"
+
+    manifest = registry.export_manifest()
+    assert any(path_str.endswith("custom_templates") for path_str in manifest["search_paths"])


### PR DESCRIPTION
## Summary
- tighten adapter export tests by enforcing __all__ presence with pytest and using order-independent comparisons
- rely on registry manifest data in preference assertions instead of touching private state
- stabilise evidence converter tests by ensuring project_generator is imported from the repository root before exercising helpers

## Testing
- pytest unified_workflow/tests/test_adapters_exports.py unified_workflow/tests/test_template_registry_unit.py unified_workflow/tests/test_evidence_schema_converter_unit.py

------
https://chatgpt.com/codex/tasks/task_e_68e3445409d4832ebe753bfaa4628c41